### PR TITLE
管理側：会員情報変更機能・宿情報一覧表示機能

### DIFF
--- a/src/main/java/com/example/hotel/Hotel.java
+++ b/src/main/java/com/example/hotel/Hotel.java
@@ -1,0 +1,67 @@
+package com.example.hotel;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "hotel")
+public class Hotel {
+    @Id
+    @Column(name = "hotel_id")
+    private String hotelId;
+
+    @Column(name = "hotel_name")
+    private String hotelName;
+
+    @Column(name = "category_code")
+    private int categoryCode;
+
+    @Column(name = "hotel_address")
+    private String hotelAddress;
+
+    @Column(name = "hotel_checkin")
+    private String hotelCheckin;
+
+    @Column(name = "hotel_checkout")
+    private String hotelCheckout;
+
+    public Hotel() {
+
+    }
+
+    public Hotel(String hotelId, String hotelName, int categoryCode,
+                  String hotelAddress, String hotelCheckin, String hotelCheckout) {
+        this.hotelId = hotelId;
+        this.hotelName = hotelName;
+        this.categoryCode = categoryCode;
+        this.hotelAddress = hotelAddress;
+        this.hotelCheckin = hotelCheckin;
+        this.hotelCheckout = hotelCheckout;
+    }
+
+    public String getHotelId() {
+        return hotelId;
+    }
+
+    public String getHotelName() {
+        return hotelName;
+    }
+
+    public int getCtegoryCode() {
+        return categoryCode;
+    }
+
+    public String getHotelAddress() {
+        return hotelAddress;
+    }
+
+    public String getHotelCheckin() {
+        return hotelCheckin;
+    }
+
+    public String getHotelCheckout() {
+        return hotelCheckout;
+    }
+}

--- a/src/main/java/com/example/hotel/HotelController.java
+++ b/src/main/java/com/example/hotel/HotelController.java
@@ -1,0 +1,38 @@
+package com.example.hotel;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+public class HotelController {
+    
+    @Autowired
+    HotelRepository hotelRepository;
+
+    @RequestMapping("/adminHotel")
+    public ModelAndView adminHotel(ModelAndView mv) {
+        mv.addObject("hotelList", hotelRepository.findAll());
+        mv.setViewName("adminHotel");
+        return mv;
+    }
+
+    //addHotel.html表示用メソッド
+    @RequestMapping("/addHotel")
+    public ModelAndView addHotel(ModelAndView mv) {
+        mv.setViewName("addHotel");
+        return mv;
+    }
+
+    //宿新規登録表示用メソッド
+    @RequestMapping("/addH")
+    public ModelAndView addH(ModelAndView mv) {
+        mv.setViewName("addHotel");
+        return mv;
+    }
+}

--- a/src/main/java/com/example/hotel/HotelRepository.java
+++ b/src/main/java/com/example/hotel/HotelRepository.java
@@ -1,0 +1,7 @@
+package com.example.hotel;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HotelRepository extends JpaRepository<Hotel, String> {
+    
+}

--- a/src/main/java/com/example/hotel/Member.java
+++ b/src/main/java/com/example/hotel/Member.java
@@ -54,6 +54,16 @@ public class Member {
         this.memberPass = memberPass;
     }
 
+    public void setUpdateMember(String memberName, String memberAddress, String memberTel,
+                  String memberEmail, String memberBirth, String memberPass) {
+        this.memberName = memberName;
+        this.memberAddress = memberAddress;
+        this.memberTel = memberTel;
+        this.memberEmail = memberEmail;
+        this.memberBirth = memberBirth;
+        this.memberPass = memberPass;
+    }
+
     public void setMemberWithdrawal(String memberWithdrawal) {
         this.memberWithdrawal = memberWithdrawal;
     }

--- a/src/main/resources/templates/admin.html
+++ b/src/main/resources/templates/admin.html
@@ -8,7 +8,7 @@
 
 <body>
 
-    <p><a href="/">ログアウト</a> <a href="/adminAddMember">新規登録</a> <a href="/adminHotel">宿情報管理</a></p>
+    <p><a href="/">ログアウト</a> <a href="/adminHotel">宿情報管理</a></p>
 
     <h1>会員一覧</h1>
     <span style="color:red;" th:text="${errorMsg}"></span>
@@ -39,10 +39,16 @@
             <td th:text="${member.memberJoin}"></td>
             <td th:text="${member.memberWithdrawal}"></td>
             <td>
-            <form action="/removeMember" method="post">
-                <input type="hidden" name="memberId" th:value="${member.memberId}">
-                <input type="submit" value="削除">
-            </form>
+                <form action="/updateMember" method="post">
+                    <input type="hidden" name="memberId" th:value="${member.memberId}">
+                    <input type="submit" value="更新">
+                </form>
+            </td>
+            <td>
+                <form action="/removeMember" method="post">
+                    <input type="hidden" name="memberId" th:value="${member.memberId}">
+                    <input type="submit" value="削除">
+                </form>
             </td>
         </tr>
     </table>

--- a/src/main/resources/templates/adminHotel.html
+++ b/src/main/resources/templates/adminHotel.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8">
+    <title>管理者ログイン</title>
+</head>
+
+<body>
+
+    <p><a href="/">ログアウト</a> <a href="/addHotel">宿新規登録</a> <a href="/admin">会員情報管理</a></p>
+
+    <h1>会員一覧</h1>
+    <span style="color:red;" th:text="${errorMsg}"></span>
+
+
+    <form action="/findhotel" method="POST">
+        <select name="serchCode">
+            <option value="0">シティホテル</option>
+            <option value="1">リゾートホテル</option>
+            <option value="2">ビジネスホテル</option>
+            <option value="3">旅館</option>
+            <option value="4">民宿</option>
+            <option value="5">ペンション</option>
+        </select>
+        <input type="text" name="freeword">
+        <p><input type="submit" value="検索"></p>
+    </form>
+
+    <table border="1">
+        <tr>
+            <th>宿ID</th><th>宿名</th><th>分類コード</th><th>住所</th><th>チェックイン</th><th>チェックアウト</th>
+        </tr>
+        <tr th:each="hotel:${hotelList}">
+            <td th:text="${hotel.hotelId}"></td>
+            <td th:text="${hotel.hotelName}"></td>
+            <td th:text="${hotel.categoryCode}"></td>
+            <td th:text="${hotel.hotelAddress}"></td>
+            <td th:text="${hotel.hotelCheckin}"></td>
+            <td th:text="${hotel.hotelCheckout}"></td>
+            <td>
+                <form action="/updateHotel" method="post">
+                    <input type="hidden" name="hotelId" th:value="${hotel.hotelId}">
+                    <input type="submit" value="更新">
+                </form>
+            </td>
+            <td>
+                <form action="/removeHotel" method="post">
+                    <input type="hidden" name="hotelId" th:value="${hotel.hotelId}">
+                    <input type="submit" value="削除">
+                </form>
+            </td>
+        </tr>
+    </table>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/updateMember.html
+++ b/src/main/resources/templates/updateMember.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="UTF-8">
+	<title>管理者ログイン</title>
+</head>
+
+<body>
+    <form action="admin"><input type="submit" value="戻る"></form>
+	<h1>会員情報更新</h1>
+    <span style="color:red;" th:text="${errorMsg}"></span>
+
+    <form action="/updateM" method="POST">
+        <p>
+            名前：<input type="text" name="memberName" th:value="${member.memberName}">
+        </p>
+
+        <p>
+            住所：<input type="text" name="memberAddress" th:value="${member.memberAddress}">
+        </p>
+
+        <p>
+            電話番号：<input type="tel" name="memberTel" th:value="${member.memberTel}">
+        </p>
+
+        <p>
+            メールアドレス：<input type="email" name="memberEmail" th:value="${member.memberEmail}">
+        </p>
+
+        <p>
+            誕生日：<input type="text" name="memberBirth" th:value="${member.memberBirth}">
+        </p>
+
+        <p>
+            パスワード：<input type="text" name="memberPass" th:value="${member.memberPass}">
+        </p>
+
+        <input type="hidden" name="memberId" th:value="${member.memberId}">
+        <input type="submit" value="更新">
+
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## 変更の概要

* 会員情報の変更機能追加
* 宿情報一覧表示機能追加

## なぜこの変更をするのか

* 会員情報の変更を可能にするため
* 宿情報を閲覧するため

## やったこと

* [x] やったこと
* 退会済みアカウントで退会動作を出来ないようにアルゴリズムを追加
* 会員情報の変更機能を追加
* 会員情報一覧表示ページの上部リンクから宿情報一覧ページに遷移出来るようにファイル追加
* 宿一覧表示機能を追加
* [ ] やっていること
* 宿新規登録機能の追加

## 変更内容

* 
![image](https://github.com/FREE-M-Y/HOTEL/assets/171751093/418974fd-2e8d-438d-8c09-62aa41a49c9b)

## どうやるのか

* 会員情報横の更新ボタンを押して変更したい会員情報を変更し、更新ボタンをクリック