### PR TITLE
管理側：宿プラン登録・変更・削除機能

### DIFF
--- a/src/main/java/com/example/hotel/HotelController.java
+++ b/src/main/java/com/example/hotel/HotelController.java
@@ -14,9 +14,13 @@ public class HotelController {
     @Autowired
     HotelRepository hotelRepository;
 
+    @Autowired
+    PlanRepository planRepository;
+
     //宿情報一覧表示用メソッド
     @RequestMapping("/adminHotel")
     public ModelAndView adminHotel(ModelAndView mv) {
+        mv.addObject("planList", planRepository.findAll());
         mv.addObject("hotelList", hotelRepository.findAll());
         mv.setViewName("adminHotel");
         return mv;

--- a/src/main/java/com/example/hotel/Plan.java
+++ b/src/main/java/com/example/hotel/Plan.java
@@ -1,0 +1,89 @@
+package com.example.hotel;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "plans")
+public class Plan {
+    @Id
+    @Column(name = "plan_id")
+    private int planId;
+
+    @Column(name = "hotel_id")
+    private String hotelId;
+
+    @Column(name = "plan_type_id")
+    private int planTypeId;
+
+    @Column(name = "plan_price")
+    private int planPrice;
+
+    @Column(name = "plan_room_count")
+    private int planRoomCount;
+
+    @Column(name = "plan_dalete_date")
+    private String planDeleteDate;
+
+    @Column(name = "plan_description")
+    private String planDescription;
+
+    public Plan() {
+
+    }
+
+    public Plan(int planId, String hotelId, int planTypeId, int planPrice,
+                  int planRoomCount, String planDeleteDate, String planDescription) {
+        this.planId = planId;
+        this.hotelId = hotelId;
+        this.planTypeId = planTypeId;
+        this.planPrice = planPrice;
+        this.planRoomCount = planRoomCount;
+        this.planDeleteDate = planDeleteDate;
+        this.planDescription = planDescription;
+    }
+
+    public void setEditPlan(int planTypeId, int planPrice, int planRoomCount,
+                            String planDeleteDate, String planDescription) {
+        this.planTypeId = planTypeId;
+        this.planPrice = planPrice;
+        this.planRoomCount = planRoomCount;
+        this.planDeleteDate = planDeleteDate;
+        this.planDescription = planDescription;
+    }
+
+    public void setPlanDeleteDate(String planDeleteDate, String planDescription) {
+        this.planDeleteDate = planDeleteDate;
+        this.planDescription = planDescription;
+    }
+
+    public int getPlanId() {
+        return planId;
+    }
+
+    public String getHotelId() {
+        return hotelId;
+    }
+
+    public int getPlanTypeId() {
+        return planTypeId;
+    }
+
+    public int getPlanPrice() {
+        return planPrice;
+    }
+
+    public int getPlanRoomCount() {
+        return planRoomCount;
+    }
+
+    public String getPlanDeleteDate() {
+        return planDeleteDate;
+    }
+
+    public String getPlanDescription() {
+        return planDescription;
+    }
+}

--- a/src/main/java/com/example/hotel/PlanController.java
+++ b/src/main/java/com/example/hotel/PlanController.java
@@ -1,0 +1,150 @@
+package com.example.hotel;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+public class PlanController {
+    
+    @Autowired
+    PlanTypeRepository planTypeRepository;
+
+    @Autowired
+    HotelRepository hotelRepository;
+
+    @Autowired
+    PlanRepository planRepository;
+
+    //addHotelPlan.html表示用メソッド
+    @RequestMapping("/addHotelPlan")
+    public ModelAndView addHotelPlan(
+        @RequestParam("hotelId") String hotelId,
+        ModelAndView mv) {
+        mv.addObject("hotelId", hotelId);
+        mv.setViewName("addHotelPlan");
+        return mv;
+    }
+
+    //プラン登録用メソッド
+    @RequestMapping("/addHP")
+    public ModelAndView addHP(
+        @RequestParam("planId") int planId,
+        @RequestParam("hotelId") String hotelId,
+        @RequestParam("planTypeId") int planTypeId,
+        @RequestParam("planPrice") int planPrice,
+        @RequestParam("planRoomCount") int planRoomCount,
+        @RequestParam("planDescription") String planDescription,
+        ModelAndView mv) {
+        
+        List<Plan> plan = planRepository.findByPlanId(planId);
+        List<PlanType> planType = planTypeRepository.findByPlanTypeIdOrPlanName(planTypeId,null);
+
+        if (plan.size() != 0) {
+            mv.addObject("errorMsg", "すでに登録されているプランIDです");
+            mv.addObject("hotelId", hotelId);
+            mv.setViewName("addHotelPlan");
+        } else if (planType.size() == 0) {
+            mv.addObject("errorMsg", "存在しないプランタイプです");
+            mv.addObject("hotelId", hotelId);
+            mv.setViewName("addHotelPlan");
+        } else {
+            planRepository.save(new Plan(planId, hotelId, planTypeId, planPrice, planRoomCount,
+                                null, planDescription));
+            
+            mv.addObject("errorMsg", "プランを登録しました。");
+            mv.addObject("planList",planRepository.findAll());
+            mv.addObject("hotelList", hotelRepository.findAll());
+            mv.setViewName("adminHotel");
+        }
+        return mv;
+    }
+
+    //editHotelPlan.html表示用メソッド
+    @RequestMapping("/editHotelPlan")
+    public ModelAndView editHotelPlan(
+        @RequestParam("hotelId") String hotelId,
+        ModelAndView mv) {
+        mv.addObject("planList",planRepository.findByHotelId(hotelId));
+        mv.setViewName("editHotelPlan");
+        return mv;
+    }
+
+    //updateHotelPlan.html表示用メソッド
+    @RequestMapping("/updateHotelPlan")
+    public ModelAndView updateHotelPlan(
+        @RequestParam("planId") int planId,
+        ModelAndView mv) {
+        mv.addObject("plan",planRepository.findByPlanId(planId).get(0));
+        mv.setViewName("updateHotelPlan");
+        return mv;
+    }
+
+    //宿プラン変更用メソッド
+    @RequestMapping("/updateHP")
+    public ModelAndView updateHP(
+        @RequestParam("planId") int planId,
+        @RequestParam("hotelId") String hotelId,
+        @RequestParam("planTypeId") int planTypeId,
+        @RequestParam("planPrice") int planPrice,
+        @RequestParam("planRoomCount") int planRoomCount,
+        @RequestParam("planDeleteDate") String planDeleteDate,
+        @RequestParam("planDescription") String planDescription,
+        ModelAndView mv) {
+        
+        List<Plan> planList = planRepository.findByPlanId(planId);
+        List<PlanType> planType = planTypeRepository.findByPlanTypeIdOrPlanName(planTypeId,null);
+
+        if (planType.size() == 0) {
+            mv.addObject("errorMsg", "存在しないプランタイプです");
+            mv.addObject("plan",planRepository.findByPlanId(planId).get(0));
+            mv.setViewName("updateHotelPlan");
+        } else {
+            planList.get(0).setEditPlan(planTypeId, planPrice, planRoomCount, planDeleteDate, planDescription);
+            planRepository.save(planList.get(0));
+            mv.addObject("errorMsg", "プランを変更しました。");
+            mv.addObject("planList",planRepository.findAll());
+            mv.addObject("hotelList", hotelRepository.findAll());
+            mv.setViewName("adminHotel");
+        }
+
+        return mv;
+    }
+
+    //removeHotelPlan.html表示用メソッド
+    @RequestMapping("/removeHotelPlan")
+    public ModelAndView removeHotelPlan(
+        @RequestParam("planId") int planId,
+        ModelAndView mv) {
+        mv.addObject("plan",planRepository.findByPlanId(planId).get(0));
+        mv.setViewName("removeHotelPlan");
+        return mv;
+    }
+
+    //宿泊プラン削除用メソッド
+    @RequestMapping("/removeHP")
+    public ModelAndView removeHP(
+        @RequestParam("planId") int planId,
+        @RequestParam("planDescription") String planDescription,
+        ModelAndView mv) {
+
+        Plan plan = planRepository.findByPlanId(planId).get(0);
+        Date date = new Date(); // 今日の日付
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy.MM.dd");
+        String strDate = dateFormat.format(date);
+        
+        plan.setPlanDeleteDate(strDate, planDescription);
+        planRepository.save(plan);            
+        mv.addObject("errorMsg", "プランを削除しました。");
+        mv.addObject("planList",planRepository.findAll());
+        mv.addObject("hotelList", hotelRepository.findAll());
+        mv.setViewName("adminHotel");
+        return mv;
+    }
+}

--- a/src/main/java/com/example/hotel/PlanRepository.java
+++ b/src/main/java/com/example/hotel/PlanRepository.java
@@ -1,0 +1,12 @@
+package com.example.hotel;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlanRepository extends JpaRepository<Plan, Integer> {
+    List<Plan> findByPlanId(int planId);
+    List<Plan> findByHotelId(String hotelId);
+}

--- a/src/main/java/com/example/hotel/PlanTypeController.java
+++ b/src/main/java/com/example/hotel/PlanTypeController.java
@@ -14,11 +14,15 @@ public class PlanTypeController {
     @Autowired
     PlanTypeRepository planTypeRepository;
 
+    @Autowired
+    PlanRepository planRepository;
+
     //プラン情報一覧表示用メソッド
     @RequestMapping("adminPlanType")
     public ModelAndView adminPlanType(
         ModelAndView mv ) {
             mv.addObject("planTypeList", planTypeRepository.findAll());
+            mv.addObject("planList", planRepository.findAll());
             mv.setViewName("adminPlanType");
             return mv;
     }

--- a/src/main/resources/templates/addHotelPlan.html
+++ b/src/main/resources/templates/addHotelPlan.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="UTF-8">
+	<title>管理者ログイン</title>
+</head>
+<body>
+    <form action="adminHotel"><input type="submit" value="戻る"></form>
+
+	<h1>宿プラン登録</h1>
+
+    <span style="color:red;" th:text="${errorMsg}"></span>
+    <form action="/addHP" method="POST">
+
+    <p>
+        プランID：<input type="number" name="planId" value="0">
+    </p>
+
+    <p>
+        宿ID：<input type="text" name="hotelId" th:value="${hotelId}" readonly>
+    </p>
+
+    <p>
+        プランタイプID：<input type="number" name="planTypeId" value="0">
+    </p>
+
+    <p>
+        金額：<input type="number" name="planPrice" value="0" min="0">
+    </p>
+
+    <p>
+        部屋数：<input type="number" name="planRoomCount" value="0">
+    </p>
+
+    <p>
+        備考：<input type="text" name="planDescription">
+    </p>
+
+    <input type="submit" value="登録">
+
+    </form>
+</body>
+</html>

--- a/src/main/resources/templates/adminHotel.html
+++ b/src/main/resources/templates/adminHotel.html
@@ -32,6 +32,7 @@
     <table border="1">
         <tr>
             <th>宿ID</th><th>宿名</th><th>分類コード</th><th>住所</th><th>チェックイン</th><th>チェックアウト</th>
+            <th>プランID</th>
         </tr>
         <tr th:each="hotel:${hotelList}">
             <td th:text="${hotel.hotelId}"></td>
@@ -40,10 +41,23 @@
             <td th:text="${hotel.hotelAddress}"></td>
             <td th:text="${hotel.hotelCheckin}"></td>
             <td th:text="${hotel.hotelCheckout}"></td>
+                    <td>
+                        <span th:each="plan:${planList}">
+                            <span th:if="${hotel.hotelId == plan.hotelId && #strings.isEmpty(plan.planDeleteDate)}"
+                                  th:text="${plan.planId}">
+                            </span><br>
+                        </span>
+                    </td>
             <td>
                 <form action="/updateHotel" method="post">
                     <input type="hidden" name="hotelId" th:value="${hotel.hotelId}">
                     <input type="submit" value="更新">
+                </form>
+            </td>
+            <td>
+                <form action="/removeHotel" method="post">
+                    <input type="hidden" name="hotelId" th:value="${hotel.hotelId}">
+                    <input type="submit" value="削除">
                 </form>
             </td>
             <td>
@@ -53,9 +67,9 @@
                 </form>
             </td>
             <td>
-                <form action="/removeHotel" method="post">
+                <form action="/editHotelPlan" method="post">
                     <input type="hidden" name="hotelId" th:value="${hotel.hotelId}">
-                    <input type="submit" value="削除">
+                    <input type="submit" value="プラン更新・削除">
                 </form>
             </td>
         </tr>

--- a/src/main/resources/templates/editHotelPlan.html
+++ b/src/main/resources/templates/editHotelPlan.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8">
+    <title>管理者ログイン</title>
+</head>
+
+<body>
+
+    <form action="adminHotel"><input type="submit" value="戻る"></form>
+
+    <h1>宿泊プラン更新</h1>
+    <span style="color:red;" th:text="${errorMsg}"></span>
+
+    <table border="1">
+        <tr>
+            <th>プランID</th><th>宿ID</th><th>プランタイプID</th><th>金額</th><th>部屋数</th><th>削除年月日</th><th>備考</th>
+        </tr>
+        <tr th:each="plan:${planList}">
+            <td th:text="${plan.planId}"></td>
+            <td th:text="${plan.hotelId}"></td>
+            <td th:text="${plan.planTypeId}"></td>
+            <td th:text="${plan.planPrice}"></td>
+            <td th:text="${plan.planRoomCount}"></td>
+            <td th:text="${plan.planDeleteDate}"></td>
+            <td th:text="${plan.planDescription}"></td>
+            <td>
+                <form action="/updateHotelPlan" method="post">
+                    <input type="hidden" name="planId" th:value="${plan.planId}">
+                    <input type="submit" value="変更">
+                </form>
+            </td>
+            <td>
+                <form action="/removeHotelPlan" method="post">
+                    <input type="hidden" name="planId" th:value="${plan.planId}">
+                    <input type="submit" value="削除">
+                </form>
+            </td>
+        </tr>
+    </table>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/removeHotelPlan.html
+++ b/src/main/resources/templates/removeHotelPlan.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head>
+    <meta charset="UTF-8">
+    <title>管理者ログイン</title>
+</head>
+
+<body>
+
+    <form action="editHotelPlan"><input type="submit" value="戻る">
+        <input type="hidden" name="hotelId" th:value="${plan.hotelId}">
+    </form>
+
+    <h1>宿泊プラン削除</h1>
+    <span style="color:red;" th:text="${errorMsg}"></span>
+
+    <table border="1">
+        <tr>
+            <th>プランID</th><th>宿ID</th><th>プランタイプID</th><th>金額</th><th>部屋数</th><th>備考</th>
+        </tr>
+        <tr>
+            <td th:text="${plan.planId}"></td>
+            <td th:text="${plan.hotelId}"></td>
+            <td th:text="${plan.planTypeId}"></td>
+            <td th:text="${plan.planPrice}"></td>
+            <td th:text="${plan.planRoomCount}"></td>
+            <td th:text="${plan.planDescription}"></td>
+        </tr>
+    </table>
+    <form action="/removeHP" method="post">
+        <p>
+            備考：<input type="text" name="planDescription" th:value="${plan.planDescription}">
+        </p>
+        <input type="hidden" name="planId" th:value="${plan.planId}">
+        <input type="submit" value="削除">
+    </form>
+
+</body>
+
+</html>

--- a/src/main/resources/templates/updateHotelPlan.html
+++ b/src/main/resources/templates/updateHotelPlan.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+	<meta charset="UTF-8">
+	<title>管理者ログイン</title>
+</head>
+<body>
+    <form action="editHotelPlan"><input type="submit" value="戻る">
+        <input type="hidden" name="hotelId" th:value="${plan.hotelId}">
+    </form>
+
+	<h1>宿プラン変更</h1>
+
+    <span style="color:red;" th:text="${errorMsg}"></span>
+    <form action="/updateHP" method="POST">
+
+    <p>
+        プランID：<input type="number" name="planId" th:value="${plan.planId}" readonly>
+    </p>
+
+    <p>
+        宿ID：<input type="text" name="hotelId" th:value="${plan.hotelId}" readonly>
+    </p>
+
+    <p>
+        プランタイプID：<input type="number" name="planTypeId" th:value="${plan.planTypeId}">
+    </p>
+
+    <p>
+        金額：<input type="number" name="planPrice" th:value="${plan.planPrice}">
+    </p>
+
+    <p>
+        部屋数：<input type="number" name="planRoomCount" th:value="${plan.planRoomCount}">
+    </p>
+
+    <p>
+        削除年月日<input type="text" name="planDeleteDate" th:value="${plan.planDeleteDate}">
+    </p>
+
+    <p>
+        備考：<input type="text" name="planDescription" th:value="${plan.planDescription}">
+    </p>
+
+    <input type="submit" value="変更">
+
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## 変更の概要

* 宿プラン登録・変更・削除機能の追加

## なぜこの変更をするのか

* 要件を満たすため

## やったこと

* [x] やったこと
* 宿泊プランの新規登録・変更・削除機能を追加
* 宿IDとプランIDを紐付けて、宿一覧に表示する機能を追加
* 削除したプランを別のプランに出来るように、プランIDと宿ID以外のプラン情報全てを変更可能で実装

## どうやるのか

* 使い方
* 宿一覧から指定した宿についてプランの追加・変更・削除を実行できる